### PR TITLE
Table update hotfix

### DIFF
--- a/dpi.py
+++ b/dpi.py
@@ -395,6 +395,9 @@ def parse_capture(capture, flows):
 
 # Obtain IP addresses associated with the specified flows
 def switch_routine(flows, captures, condition, bmv2_json, p4info):
+    # Set the forwarding pipeline config
+    # This also clears all tables
+    subprocess.run(['./set_pipeline_conf.py', bmv2_json, p4info])
     # Continuously wait and process capture outputs
     while True:
         with condition:

--- a/set_pipeline_conf.py
+++ b/set_pipeline_conf.py
@@ -37,19 +37,11 @@ def main(argv):
 
         switch_connection.MasterArbitrationUpdate()
 
+        switch_connection.SetForwardingPipelineConfig(p4info=p4info_helper.p4info,
+                                       bmv2_json_file_path=argv[1])
     except grpc.RpcError as e:
         printGrpcError(e)
         return
-
-    table_entry = p4info_helper.buildTableEntry(
-        table_name="ingress.blocklist",
-        match_fields={
-            "hdr.ipv4.srcAddr": argv[3],
-            "hdr.ipv4.dstAddr": argv[4]
-        },
-        action_name="my_drop",
-        )
-    switch_connection.WriteTableEntry(table_entry)
 
 if __name__ == "__main__":
     main(sys.argv)


### PR DESCRIPTION
This fixes a bug where every table update clears the tables.

In order to fix this, I've moved the `SetForwardingPipelineConfig` call from `blocklist_add.py` (which clears the tables while setting the config) into a separate script, `set_pipeline_conf.py`.  
I call the `set_pipeline_conf.py` script in the beginning of `switch_routine()` in `dpi.py`, which sets the config and clears the tables only once, when the program is started.